### PR TITLE
access_tokenが平文で保存されていた点を修正

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -13,7 +13,7 @@ android {
 
     defaultConfig {
         applicationId = "com.example.githubclient"
-        minSdk = 23
+        minSdk = 26
         targetSdk = 33
         versionCode = 1
         versionName = "1.0"
@@ -54,6 +54,8 @@ dependencies {
     implementation(project(":feature:search"))
     implementation(project(":feature:setting"))
     implementation(project(":feature:favorite"))
+    implementation(project(":core:data"))
+
     implementation("androidx.core:core-ktx:1.9.0")
     implementation("androidx.lifecycle:lifecycle-runtime-ktx:2.5.1")
     implementation("androidx.activity:activity-compose:1.6.1")

--- a/app/src/main/java/com/example/githubclient/MainActivity.kt
+++ b/app/src/main/java/com/example/githubclient/MainActivity.kt
@@ -1,5 +1,6 @@
 package com.example.githubclient
 
+import android.content.SharedPreferences
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
@@ -10,9 +11,11 @@ import androidx.compose.ui.Modifier
 import com.example.githubclient.ui.GithubClientApp
 import com.example.githubclient.ui.theme.GithubClientTheme
 import dagger.hilt.android.AndroidEntryPoint
+import javax.inject.Inject
 
 @AndroidEntryPoint
 class MainActivity : ComponentActivity() {
+    @Inject lateinit var encryptedPref: SharedPreferences
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContent {
@@ -22,7 +25,7 @@ class MainActivity : ComponentActivity() {
                     modifier = Modifier.fillMaxSize(),
                     color = MaterialTheme.colorScheme.background
                 ) {
-                    GithubClientApp()
+                    GithubClientApp(encryptedPref)
                 }
             }
         }

--- a/app/src/main/java/com/example/githubclient/navigation/GithubClientNavHost.kt
+++ b/app/src/main/java/com/example/githubclient/navigation/GithubClientNavHost.kt
@@ -1,8 +1,8 @@
 package com.example.githubclient.navigation
 
+import android.content.SharedPreferences
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalContext
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import com.example.favorite.navigation.favoriteScreen
@@ -14,11 +14,11 @@ import com.example.setting.navigation.settingScreen
 
 @Composable
 fun GithubClientNavHost(
+    encryptedPref: SharedPreferences,
     navController: NavHostController,
     modifier: Modifier = Modifier,
     startDestination: String = SEARCH_NAVIGATION_ROUTE
 ) {
-    val context = LocalContext.current
     NavHost(navController = navController, startDestination = startDestination, modifier = modifier) {
         searchScreen(
             onUserRowClick = { userName -> navController.navigateToDetail(userName) },
@@ -26,8 +26,8 @@ fun GithubClientNavHost(
         )
         favoriteScreen()
         settingScreen(
-            navigateToLoginScreen = { navController.navigateToAccount(context) },
-            navigateToAccountScreen = { navController.navigateToAccount(context) }
+            navigateToLoginScreen = { navController.navigateToAccount(encryptedPref) },
+            navigateToAccountScreen = { navController.navigateToAccount(encryptedPref) }
         )
     }
 }

--- a/app/src/main/java/com/example/githubclient/ui/GithubClientApp.kt
+++ b/app/src/main/java/com/example/githubclient/ui/GithubClientApp.kt
@@ -1,5 +1,6 @@
 package com.example.githubclient.ui
 
+import android.content.SharedPreferences
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -19,7 +20,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
-import androidx.compose.ui.platform.LocalContext
 import androidx.navigation.NavController
 import androidx.navigation.compose.rememberNavController
 import com.example.favorite.navigation.navigateToFavorite
@@ -29,13 +29,14 @@ import com.example.setting.navigation.navigateToAccount
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun GithubClientApp(modifier: Modifier = Modifier) {
+fun GithubClientApp(encryptedPref: SharedPreferences, modifier: Modifier = Modifier) {
     val navController = rememberNavController()
     Scaffold(
         modifier = modifier,
-        bottomBar = { GithubClientBottomBar(navController = navController) }
+        bottomBar = { GithubClientBottomBar(encryptedPref, navController = navController) }
     ) { innerPadding ->
         GithubClientNavHost(
+            encryptedPref = encryptedPref,
             navController = navController,
             modifier = Modifier.padding(innerPadding)
         )
@@ -43,8 +44,11 @@ fun GithubClientApp(modifier: Modifier = Modifier) {
 }
 
 @Composable
-fun GithubClientBottomBar(navController: NavController, modifier: Modifier = Modifier) {
-    val context = LocalContext.current
+fun GithubClientBottomBar(
+    encryptedPref: SharedPreferences,
+    navController: NavController,
+    modifier: Modifier = Modifier
+) {
     BottomAppBar(modifier = modifier.fillMaxWidth()) {
         Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceEvenly) {
             BottomAppBarItem(
@@ -60,7 +64,7 @@ fun GithubClientBottomBar(navController: NavController, modifier: Modifier = Mod
             BottomAppBarItem(
                 iconImageVector = Icons.Default.AccountCircle,
                 iconDescription = "account",
-                onClick = { navController.navigateToAccount(context = context) }
+                onClick = { navController.navigateToAccount(encryptedPref = encryptedPref) }
             )
         }
     }
@@ -73,7 +77,10 @@ fun BottomAppBarItem(
     modifier: Modifier = Modifier,
     onClick: () -> Unit = {}
 ) {
-    Column(modifier = modifier.clickable(onClick = onClick), horizontalAlignment = Alignment.CenterHorizontally) {
+    Column(
+        modifier = modifier.clickable(onClick = onClick),
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
         Icon(imageVector = iconImageVector, contentDescription = iconDescription)
         Text(text = iconDescription)
     }

--- a/core/data/build.gradle.kts
+++ b/core/data/build.gradle.kts
@@ -48,6 +48,7 @@ dependencies {
     implementation("org.jetbrains.kotlinx:kotlinx-collections-immutable:0.3.5")
     detektPlugins("com.twitter.compose.rules:detekt:0.0.26")
     detektPlugins("io.gitlab.arturbosch.detekt:detekt-formatting:1.22.0")
+    implementation("androidx.security:security-crypto:1.0.0")
     testImplementation("junit:junit:4.13.2")
     androidTestImplementation("androidx.test.ext:junit:1.1.4")
     androidTestImplementation("androidx.test.espresso:espresso-core:3.5.0")

--- a/core/data/src/main/java/com/example/data/auth/di/EncryptedSharedPreferencesModule.kt
+++ b/core/data/src/main/java/com/example/data/auth/di/EncryptedSharedPreferencesModule.kt
@@ -1,0 +1,31 @@
+package com.example.data.auth.di
+
+import android.content.Context
+import android.content.SharedPreferences
+import androidx.security.crypto.EncryptedSharedPreferences
+import androidx.security.crypto.MasterKeys
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.android.qualifiers.ApplicationContext
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+object EncryptedSharedPreferencesModule {
+    @Provides
+    @Singleton
+    fun provideEncryptedSharedPreferences(
+        @ApplicationContext context: Context
+    ): SharedPreferences {
+        val masterKeys = MasterKeys.getOrCreate(MasterKeys.AES256_GCM_SPEC)
+        return EncryptedSharedPreferences.create(
+            "encrypted_preferences",
+            masterKeys,
+            context,
+            EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
+            EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM
+        )
+    }
+}

--- a/feature/favorite/build.gradle.kts
+++ b/feature/favorite/build.gradle.kts
@@ -11,7 +11,7 @@ android {
     compileSdk = 33
 
     defaultConfig {
-        minSdk = 23
+        minSdk = 26
         targetSdk = 33
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"

--- a/feature/search/build.gradle.kts
+++ b/feature/search/build.gradle.kts
@@ -12,7 +12,7 @@ android {
     compileSdk = 33
 
     defaultConfig {
-        minSdk = 23
+        minSdk = 26
         targetSdk = 33
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"

--- a/feature/search/src/main/java/com/example/search/ui/search/SearchScreen.kt
+++ b/feature/search/src/main/java/com/example/search/ui/search/SearchScreen.kt
@@ -1,6 +1,5 @@
 package com.example.search.ui.search
 
-import android.content.Context
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
@@ -42,7 +41,6 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.graphics.vector.rememberVectorPainter
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.style.TextAlign
@@ -74,7 +72,7 @@ fun SearchRoute(
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun SearchScreen(
-    onSearch: (String, String) -> Unit,
+    onSearch: (String) -> Unit,
     onWordChange: (String) -> Unit,
     onClickForDetail: (String) -> Unit,
     onClickForSave: (GithubUserItem) -> Unit,
@@ -106,7 +104,7 @@ fun SearchScreen(
 
 @Composable
 private fun SearchTextFieldAppBar(
-    onSearch: (String, String) -> Unit,
+    onSearch: (String) -> Unit,
     onWordChange: (String) -> Unit,
     searchWord: String,
     modifier: Modifier = Modifier,
@@ -123,14 +121,13 @@ private fun SearchTextFieldAppBar(
 @OptIn(ExperimentalComposeUiApi::class, ExperimentalMaterial3Api::class)
 @Composable
 private fun SearchTextField(
-    onSearch: (String, String) -> Unit,
+    onSearch: (String) -> Unit,
     word: String,
     onWordChange: (String) -> Unit,
     modifier: Modifier = Modifier
 ) {
     val keyboardController = LocalSoftwareKeyboardController.current
     val focusRequester = remember { FocusRequester() }
-    val context = LocalContext.current
     LaunchedEffect(Unit) {
         focusRequester.requestFocus()
     }
@@ -155,10 +152,7 @@ private fun SearchTextField(
             }
         },
         keyboardActions = KeyboardActions(onDone = {
-            val accessToken =
-                context.getSharedPreferences("com.example.githubclient", Context.MODE_PRIVATE)
-                    .getString("accessToken", "")
-            onSearch(word, accessToken!!)
+            onSearch(word)
             keyboardController?.hide()
         }),
         singleLine = true,
@@ -261,7 +255,7 @@ val fakeRepositoryList =
         )
     }
 
-private val previewFun = { _: String, _: String -> }
+private val previewFun = { _: String -> }
 
 @Preview
 @Composable

--- a/feature/search/src/main/java/com/example/search/ui/search/SearchViewModel.kt
+++ b/feature/search/src/main/java/com/example/search/ui/search/SearchViewModel.kt
@@ -1,5 +1,7 @@
 package com.example.search.ui.search
 
+import android.content.SharedPreferences
+import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.example.data.search.GithubUserItem
@@ -15,19 +17,22 @@ import javax.inject.Inject
 
 @HiltViewModel
 class SearchViewModel @Inject constructor(
-    private val searchRepository: SearchRepository
+    private val searchRepository: SearchRepository,
+    private val encryptedSharedPreferences: SharedPreferences
 ) : ViewModel() {
     private val _searchUiState: MutableStateFlow<SearchUiState> =
         MutableStateFlow(SearchUiState())
 
     val searchUiState: StateFlow<SearchUiState> = _searchUiState
 
-    fun onSearchUsers(word: String, accessToken: String) {
+    fun onSearchUsers(word: String) {
         viewModelScope.launch {
             _searchUiState.update {
                 it.copy(isLoading = true)
             }
-            searchRepository.searchUsers(word = word, accessToken = accessToken).catch {
+            val accessToken = encryptedSharedPreferences.getString("access_token", "")
+            Log.d("hoge", accessToken.toString())
+            searchRepository.searchUsers(word = word, accessToken = accessToken!!).catch {
                 _searchUiState.update {
                     it.copy(isLoading = false, isError = true)
                 }

--- a/feature/setting/build.gradle.kts
+++ b/feature/setting/build.gradle.kts
@@ -16,7 +16,7 @@ android {
     compileSdk = 32
 
     defaultConfig {
-        minSdk = 23
+        minSdk = 26
         targetSdk = 32
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"

--- a/feature/setting/src/main/java/com/example/setting/navigation/SettingNavigation.kt
+++ b/feature/setting/src/main/java/com/example/setting/navigation/SettingNavigation.kt
@@ -1,6 +1,6 @@
 package com.example.setting.navigation
 
-import android.content.Context
+import android.content.SharedPreferences
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.ui.Modifier
 import androidx.navigation.NavController
@@ -15,9 +15,8 @@ private const val LOGIN_NAVIGATION_ROUTE = "setting_route"
 private const val PROGRESS_NAVIGATION_ROUTE = "progress_route"
 private const val ACCOUNT_NAVIGATION_ROUTE = "account_route"
 private const val CALLBACK_URI = "org.example.android.t179a://callback"
-fun NavController.navigateToAccount(context: Context) {
-    val pref = context.getSharedPreferences("com.example.githubclient", Context.MODE_PRIVATE)
-    val accessToken = pref.getString("accessToken", "")
+fun NavController.navigateToAccount(encryptedPref: SharedPreferences) {
+    val accessToken = encryptedPref.getString("access_token", "")
     if (accessToken!!.isEmpty()) {
         this.navigate(LOGIN_NAVIGATION_ROUTE)
     } else {

--- a/feature/setting/src/main/java/com/example/setting/ui/account/AccountScreen.kt
+++ b/feature/setting/src/main/java/com/example/setting/ui/account/AccountScreen.kt
@@ -1,6 +1,5 @@
 package com.example.setting.ui.account
 
-import android.content.Context
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -10,16 +9,14 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalContext
+import androidx.hilt.navigation.compose.hiltViewModel
 
 @Composable
 fun AccountScreen(
+    navigateToLoginScreen: () -> Unit,
     modifier: Modifier = Modifier,
-    navigateToLoginScreen: () -> Unit
+    viewModel: AccountViewModel = hiltViewModel()
 ) {
-    val context = LocalContext.current
-    val pref = context.getSharedPreferences("com.example.githubclient", Context.MODE_PRIVATE)
-
     Box(modifier = modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
         Column(
             modifier = Modifier.fillMaxSize(),
@@ -28,7 +25,7 @@ fun AccountScreen(
         ) {
             Text(text = "Account Screen")
             Button(onClick = {
-                pref.edit().remove("accessToken").apply()
+                viewModel.deleteAccessToken()
                 navigateToLoginScreen()
             }) {
                 Text("Logout")

--- a/feature/setting/src/main/java/com/example/setting/ui/account/AccountViewModel.kt
+++ b/feature/setting/src/main/java/com/example/setting/ui/account/AccountViewModel.kt
@@ -1,0 +1,20 @@
+package com.example.setting.ui.account
+
+import android.content.SharedPreferences
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class AccountViewModel @Inject constructor(private val encryptedPref: SharedPreferences) : ViewModel() {
+
+    fun deleteAccessToken() {
+        viewModelScope.launch {
+            encryptedPref.edit().apply {
+                remove("access_token")
+            }.apply()
+        }
+    }
+}

--- a/feature/setting/src/main/java/com/example/setting/ui/login/LoginScreen.kt
+++ b/feature/setting/src/main/java/com/example/setting/ui/login/LoginScreen.kt
@@ -17,22 +17,20 @@ import androidx.core.content.ContextCompat
 import com.example.setting.BuildConfig
 import java.util.UUID
 
-private const val AUTHURL = "https://github.com/login/oauth/authorize"
-private const val REDIRECTURL = "org.example.android.t179a://callback"
+private const val AUTH_URL = "https://github.com/login/oauth/authorize"
+private const val REDIRECT_URL = "org.example.android.t179a://callback"
 
 @Composable
 fun LoginScreen(modifier: Modifier = Modifier) {
     val context = LocalContext.current
 
     Box(modifier = modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-        val oAuthState: String = UUID.randomUUID().toString()
-        context.getSharedPreferences("com.example.githubclient", Context.MODE_PRIVATE).edit().apply {
-            putString("oAuthState", oAuthState)
-            apply()
-        }
+        val oAuthState: String = createOauthState()
+        saveToSharedPreference(context, "oAuthState", oAuthState)
         val uri =
-            Uri.parse(AUTHURL).buildUpon().appendQueryParameter("client_id", BuildConfig.CLIENT_ID)
-                .appendQueryParameter("redirect_uri", REDIRECTURL).appendQueryParameter("state", oAuthState).build()
+            Uri.parse(AUTH_URL).buildUpon().appendQueryParameter("client_id", BuildConfig.CLIENT_ID)
+                .appendQueryParameter("redirect_uri", REDIRECT_URL)
+                .appendQueryParameter("state", oAuthState).build()
         val loginIntent = Intent(Intent.ACTION_VIEW, uri)
         Column(
             modifier = Modifier.fillMaxSize(),
@@ -46,5 +44,16 @@ fun LoginScreen(modifier: Modifier = Modifier) {
                 Text(text = "Login")
             }
         }
+    }
+}
+
+private fun createOauthState(): String {
+    return UUID.randomUUID().toString()
+}
+
+private fun saveToSharedPreference(context: Context, keyName: String, value: String) {
+    context.getSharedPreferences("com.example.githubclient", Context.MODE_PRIVATE).edit().apply {
+        putString(keyName, value)
+        apply()
     }
 }

--- a/feature/setting/src/main/java/com/example/setting/ui/progress/ProgressScreen.kt
+++ b/feature/setting/src/main/java/com/example/setting/ui/progress/ProgressScreen.kt
@@ -35,18 +35,13 @@ fun ProgressScreen(
         viewModel.getAccessToken(callbackCode!!)
     }
 
-    if (uiState.accessToken.isEmpty()) {
+    if (uiState.loginDate.isEmpty()) {
         Box(modifier = modifier, contentAlignment = Alignment.Center) {
             CircularProgressIndicator()
         }
     } else {
         if (receivedState == submittedState) {
-            LaunchedEffect(key1 = uiState.accessToken) {
-                activity.getSharedPreferences("com.example.githubclient", Context.MODE_PRIVATE)
-                    ?.edit()?.apply {
-                        putString("accessToken", uiState.accessToken)
-                        apply()
-                    }
+            LaunchedEffect(key1 = uiState.loginDate) {
                 navigateToAccountScreen()
             }
         }

--- a/feature/setting/src/main/java/com/example/setting/ui/progress/ProgressViewModel.kt
+++ b/feature/setting/src/main/java/com/example/setting/ui/progress/ProgressViewModel.kt
@@ -1,5 +1,6 @@
 package com.example.setting.ui.progress
 
+import android.content.SharedPreferences
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.example.data.auth.AuthRepository
@@ -8,10 +9,14 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import java.time.LocalDateTime
 import javax.inject.Inject
 
 @HiltViewModel
-class ProgressViewModel @Inject constructor(private val authRepository: AuthRepository) :
+class ProgressViewModel @Inject constructor(
+    private val authRepository: AuthRepository,
+    private val encryptedPref: SharedPreferences
+) :
     ViewModel() {
     private val _uiState = MutableStateFlow(AccountUiState())
     val uiState = _uiState
@@ -22,12 +27,15 @@ class ProgressViewModel @Inject constructor(private val authRepository: AuthRepo
                 clientSecret = BuildConfig.CLIENT_SECRET,
                 code = code
             ).collect { authResponse ->
-                _uiState.update { it.copy(accessToken = authResponse.accessToken) }
+                _uiState.update { it.copy(loginDate = LocalDateTime.now().toString()) }
+                encryptedPref.edit().apply {
+                    putString("access_token", authResponse.accessToken)
+                }.apply()
             }
         }
     }
 }
 
 data class AccountUiState(
-    val accessToken: String = ""
+    val loginDate: String = ""
 )


### PR DESCRIPTION
## Issue
- close #8

## Overview (Required)
- access_tokenの保存をEncryptedSharedPrefenrecesに変更
- minSdkを26に上げた

## Links
-

## Screenshot
Before | After
:--: | :--:
<img src="" width="300" /> | <img src="" width="300" />